### PR TITLE
Sort indeces in increasing order for HDF5

### DIFF
--- a/molecules/ml/datasets/point_cloud.py
+++ b/molecules/ml/datasets/point_cloud.py
@@ -131,7 +131,7 @@ class PointCloudDataset(Dataset):
             # select points to read
             point_indices = self.rng.choice(self.num_points_total, size = self.num_points,
                                             replace = False, shuffle = False)
-
+            point_indices.sort()
             # read
             self.token[0, ...] = self.dset[index, :, point_indices]
         else:            


### PR DESCRIPTION
HDF5 insists that the indeces be in increasing order when retrieving data. However, when Python selects a random subset of indeces the order is not guaranteed causing the data retrieval to fail. Sorting the indeces fixes this problem.