### PR TITLE
Fix/conv1d

### DIFF
--- a/molecules/ml/datasets/point_cloud.py
+++ b/molecules/ml/datasets/point_cloud.py
@@ -131,7 +131,7 @@ class PointCloudDataset(Dataset):
             # select points to read
             point_indices = self.rng.choice(self.num_points_total, size = self.num_points,
                                             replace = False, shuffle = False)
-
+            point_indices.sort()
             # read
             self.token[0, ...] = self.dset[index, :, point_indices]
         else:            

--- a/molecules/ml/unsupervised/point_autoencoder/aae.py
+++ b/molecules/ml/unsupervised/point_autoencoder/aae.py
@@ -191,6 +191,9 @@ class Encoder(nn.Module):
         layers = OrderedDict([('enc_conv1', nn.Conv1d(in_channels = (3 + self.num_features),
                                                       out_channels = hparams.encoder_filters[0],
                                                       kernel_size = hparams.encoder_kernel_sizes[0],
+                                                      dilation = hparams.encoder_dilation[0],
+                                                      padding = hparams.encoder_padding[0],
+                                                      stride = hparams.encoder_stride[0],
                                                       bias = self.use_bias)),
                               ('enc_relu1', self.activation(**self.activ_args))])
 
@@ -199,6 +202,9 @@ class Encoder(nn.Module):
             layers.update({'enc_conv{}'.format(idx+1) : nn.Conv1d(in_channels = hparams.encoder_filters[idx - 1],
                                                                   out_channels = hparams.encoder_filters[idx],
                                                                   kernel_size = hparams.encoder_kernel_sizes[idx],
+                                                                  dilation = hparams.encoder_dilation[idx],
+                                                                  padding = hparams.encoder_padding[idx],
+                                                                  stride = hparams.encoder_stride[idx],
                                                                   bias = self.use_bias)})
             layers.update({'enc_relu{}'.format(idx+1) : self.activation(**self.activ_args)})
             
@@ -206,6 +212,9 @@ class Encoder(nn.Module):
         layers.update({'enc_conv{}'.format(idx+2) : nn.Conv1d(in_channels = hparams.encoder_filters[-2],
                                                               out_channels = hparams.encoder_filters[-1],
                                                               kernel_size = hparams.encoder_kernel_sizes[-1],
+                                                              dilation = hparams.encoder_dilation[-1],
+                                                              padding = hparams.encoder_padding[-1],
+                                                              stride = hparams.encoder_stride[-1],
                                                               bias = self.use_bias)})
 
         # construct model

--- a/molecules/ml/unsupervised/point_autoencoder/hyperparams.py
+++ b/molecules/ml/unsupervised/point_autoencoder/hyperparams.py
@@ -5,6 +5,9 @@ class AAE3dHyperparams(Hyperparams):
                  num_features = 1,
                  encoder_filters = [64, 128, 256, 256, 512],
                  encoder_kernel_sizes = [1, 1, 1, 1, 1],
+                 encoder_dilation = [1, 1, 1, 1, 1],
+                 encoder_padding = [0, 0, 0, 0, 0],
+                 encoder_stride = [1, 1, 1, 1, 1],
                  generator_filters = [64, 128, 512, 1024],
                  discriminator_filters = [512, 512, 128, 64],
                  latent_dim = 256,
@@ -23,6 +26,9 @@ class AAE3dHyperparams(Hyperparams):
         self.num_features = num_features
         self.encoder_filters = encoder_filters
         self.encoder_kernel_sizes = encoder_kernel_sizes
+        self.encoder_dilation = encoder_dilation
+        self.encoder_padding = encoder_padding
+        self.encoder_stride = encoder_stride
         self.generator_filters = generator_filters
         self.discriminator_filters = discriminator_filters
         self.latent_dim = latent_dim


### PR DESCRIPTION
For the correct specification of the 1D convolutions additional hyper-parameters are required. These parameters are:
* dilation
* padding
* stride

This fix adds the code required for these hyper-parameters. 
See also https://pytorch.org/docs/stable/generated/torch.nn.Conv1d.html for more information about these hyper-parameters.