### PR TITLE
sklearn is deprecated and to be replace with scikit-learn

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     tqdm
     wandb
     Pillow
-    sklearn
+    scikit-learn
 python_requires = >=3.6
 
 [options.packages.find]


### PR DESCRIPTION
Trying to install DeepDriveMD-pipeline generates complaints about the use of sklearn. Apparently sklearn has been deprecated and should be replaced by scikit-learn. 
This PR fixes the dependency of molecules on sklearn and replaces it with scikit-learn.